### PR TITLE
Bump `ghostwriter/case-converter` from `1.0.0` to `2.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "ghostwriter/case-converter": "^1.0.0",
+        "ghostwriter/case-converter": "^2.0.0",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "dev-main",
         "ghostwriter/container": "^4.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35bed1d06821d3b67de75e1c638ecb7c",
+    "content-hash": "7665376d40903e15fab41bd3e50f5970",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/case-converter.git",
-                "reference": "69a981f3532d86313e5b5a4b37ca1d64659a0caa"
+                "reference": "e3479766f945d78c3e6a64569d8293cf6fe7b80e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/69a981f3532d86313e5b5a4b37ca1d64659a0caa",
-                "reference": "69a981f3532d86313e5b5a4b37ca1d64659a0caa",
+                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/e3479766f945d78c3e6a64569d8293cf6fe7b80e",
+                "reference": "e3479766f945d78c3e6a64569d8293cf6fe7b80e",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "^0.2 || ^0.3 || ^1.0"
+                "ghostwriter/coding-standard": "dev-main"
             },
             "type": "library",
             "autoload": {
@@ -46,7 +45,7 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Convert strings from and to Ada, Camel, Cobol, Kebab, Lower, Macro, Pascal, Sentence, Snake, Title, Train, and Upper cases",
+            "description": "Convert strings from and to AdaCase, CamelCase, CobolCase, KebabCase, Lowercase, MacroCase, PascalCase, SentenceCase, SnakeCase, TitleCase, TrainCase, and Uppercase",
             "homepage": "https://github.com/ghostwriter/case-converter",
             "keywords": [
                 "ada-case",
@@ -65,10 +64,9 @@
                 "upper-case"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/case-converter",
-                "forum": "https://github.com/ghostwriter/case-converter/discussions",
                 "issues": "https://github.com/ghostwriter/case-converter/issues",
                 "rss": "https://github.com/ghostwriter/case-converter/releases.atom",
+                "security": "https://github.com/ghostwriter/case-converter/security/advisories/new",
                 "source": "https://github.com/ghostwriter/case-converter"
             },
             "funding": [
@@ -77,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-10T19:54:53+00:00"
+            "time": "2025-02-06T12:07:45+00:00"
         },
         {
             "name": "ghostwriter/collection",


### PR DESCRIPTION
Bumps `ghostwriter/case-converter` from `1.0.0` to `2.0.0`.