### PR TITLE
Bump `symfony/var-dumper` from `v7.3.0` to `v7.3.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,12 @@
             "url": "https://github.com/sponsors/ghostwriter"
         }
     ],
-    "_comment": ["#BlackLivesMatter", "#FreePalestine", "#StandWithUkraine", "#StopGenocide"],
+    "_comment": [
+        "#BlackLivesMatter",
+        "#FreePalestine",
+        "#StandWithUkraine",
+        "#StopGenocide"
+    ],
     "require": {
         "php": "^8.4",
         "ghostwriter/case-converter": "~2.0.0 || ~2.1.0",
@@ -48,7 +53,7 @@
         "infection/infection": "~0.29.14",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.3",
-        "symfony/var-dumper": "~7.3.0",
+        "symfony/var-dumper": "~7.3.1",
         "vimeo/psalm": "~6.12.0"
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12e36e9c587dcf2f809c2a488e754edb",
+    "content-hash": "f485f593bb5b2d58466d9d4fc7f5eb9b",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -7271,16 +7271,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.0",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "548f6760c54197b1084e1e5c71f6d9d523f2f78e"
+                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/548f6760c54197b1084e1e5c71f6d9d523f2f78e",
-                "reference": "548f6760c54197b1084e1e5c71f6d9d523f2f78e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
+                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
                 "shasum": ""
             },
             "require": {
@@ -7335,7 +7335,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -7351,7 +7351,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-27T18:39:23+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "thecodingmachine/safe",


### PR DESCRIPTION
Bumps `symfony/var-dumper` from `v7.3.0` to `v7.3.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`