### PR TITLE
Bump `php` from `~8.4.0` to `~8.4.0 || ~8.5.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "#StopGenocide"
     ],
     "require": {
-        "php": "~8.4.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ghostwriter/case-converter": "~2.1.0",
         "ghostwriter/collection": "~2.0.0",
         "ghostwriter/config": "~1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba0578a691649e0b4b0b390362809120",
+    "content-hash": "10c2e94c1e32613d9196d103d442fc27",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -7030,7 +7030,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.4.0"
+        "php": "~8.4.0 || ~8.5.0"
     },
     "platform-dev": {
         "ext-xdebug": "*"


### PR DESCRIPTION
Bumps `php` from `~8.4.0` to `~8.4.0 || ~8.5.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`