### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#53d9149` to `dev-main#42bc537`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "ghostwriter/coding-standard": "dev-main#53d9149",
+        "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.3.7",
         "symfony/var-dumper": "~7.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39f5457ad184479a38d0463b53b1a3ce",
+    "content-hash": "d3ef61a9a09f9bc59f9491ef38130ebb",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -2411,12 +2411,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "53d9149"
+                "reference": "42bc5377685afd75db208f70f5eb9277c926db5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/53d9149",
-                "reference": "53d9149",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/42bc5377685afd75db208f70f5eb9277c926db5f",
+                "reference": "42bc5377685afd75db208f70f5eb9277c926db5f",
                 "shasum": ""
             },
             "require": {
@@ -2573,7 +2573,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-28T09:41:39+00:00"
+            "time": "2025-08-28T14:39:24+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#53d9149` to `dev-main#42bc537`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`