### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#e84283b`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1305,12 +1305,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "fff26cd848bc705a24156358e4f5efb3b49874a2"
+                "reference": "e84283bc6d2fcf38ea9092d83609295645b61c48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/fff26cd848bc705a24156358e4f5efb3b49874a2",
-                "reference": "fff26cd848bc705a24156358e4f5efb3b49874a2",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e84283bc6d2fcf38ea9092d83609295645b61c48",
+                "reference": "e84283bc6d2fcf38ea9092d83609295645b61c48",
                 "shasum": ""
             },
             "require": {
@@ -1466,7 +1466,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-02T14:11:39+00:00"
+            "time": "2025-09-02T22:10:15+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#fff26cd` to `dev-main#e84283b`.

This pull request changes the following file(s): 

- Update `composer.lock`