### PR TITLE
Update ghostwriter/coding-standard to version dev-main#6360ee0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1250,12 +1250,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f3c3de98f47dbbf5b2fd7f9b4511b6c78ec9a8f8"
+                "reference": "6360ee0ff32f2c000e7179a2637711e641c0c701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f3c3de98f47dbbf5b2fd7f9b4511b6c78ec9a8f8",
-                "reference": "f3c3de98f47dbbf5b2fd7f9b4511b6c78ec9a8f8",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/6360ee0ff32f2c000e7179a2637711e641c0c701",
+                "reference": "6360ee0ff32f2c000e7179a2637711e641c0c701",
                 "shasum": ""
             },
             "require": {
@@ -1299,7 +1299,6 @@
             },
             "default-branch": true,
             "bin": [
-                "tools/phar/composer",
                 "tools/phar/composer-normalize",
                 "tools/phar/composer-require-checker",
                 "tools/phar/composer-unused",
@@ -1400,7 +1399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-02T23:22:26+00:00"
+            "time": "2025-11-04T14:04:46+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#f3c3de9` to `dev-main#6360ee0`.

This pull request changes the following file(s): 

- Update `composer.lock`