### PR TITLE
Update ghostwriter/shell to version 0.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ghostwriter/json": "^3.0.1",
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0",
-        "ghostwriter/shell": "^0.1.2"
+        "ghostwriter/shell": "^0.1.4"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "818e0e458025edf328eb80fe7e5e355c",
+    "content-hash": "b87d5c8f661fd804a2d36da1c3c6362f",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -604,16 +604,16 @@
         },
         {
             "name": "ghostwriter/shell",
-            "version": "0.1.2",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/shell.git",
-                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109"
+                "reference": "52baa393e18d9db93f479c96241d6d644ec07f10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/e6367b96cd6be790291bc23c1e5d3aa607335109",
-                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109",
+                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/52baa393e18d9db93f479c96241d6d644ec07f10",
+                "reference": "52baa393e18d9db93f479c96241d6d644ec07f10",
                 "shasum": ""
             },
             "require": {
@@ -625,7 +625,7 @@
                 "ghostwriter/container": "^6.0.1",
                 "mockery/mockery": "^1.6.12",
                 "phpunit/phpunit": "^12.5.7",
-                "symfony/var-dumper": "^8.0.3"
+                "symfony/var-dumper": "^8.0.4"
             },
             "type": "library",
             "extra": {
@@ -675,7 +675,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-25T08:43:34+00:00"
+            "time": "2026-01-25T16:15:33+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Updates the `ghostwriter/shell` dependency from `0.1.2` to `0.1.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`