### PR TITLE
Update boundwize/structarmed to version 0.6.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.16",
+        "boundwize/structarmed": "^0.6.17",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9be1b7b6a379b168527bb4ce90a10bf",
+    "content-hash": "24d7fbb892659d3d84f2a0d5a4084762",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -854,16 +854,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.16",
+            "version": "0.6.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "8df4838a8266ed13867f9647ac52d98fc5a307d4"
+                "reference": "bb3f33323796807af7b3d9f439d6a6f2d9066afc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/8df4838a8266ed13867f9647ac52d98fc5a307d4",
-                "reference": "8df4838a8266ed13867f9647ac52d98fc5a307d4",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/bb3f33323796807af7b3d9f439d6a6f2d9066afc",
+                "reference": "bb3f33323796807af7b3d9f439d6a6f2d9066afc",
                 "shasum": ""
             },
             "require": {
@@ -912,7 +912,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.16"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.17"
             },
             "funding": [
                 {
@@ -920,7 +920,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T05:21:20+00:00"
+            "time": "2026-05-21T09:45:33+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -989,16 +989,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f40d7d3a923f6645a95b736fdeb625399bc8b0bb"
+                "reference": "154afe0378cd04b3bb6de6ab01b3c00ddfdd43fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f40d7d3a923f6645a95b736fdeb625399bc8b0bb",
-                "reference": "f40d7d3a923f6645a95b736fdeb625399bc8b0bb",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/154afe0378cd04b3bb6de6ab01b3c00ddfdd43fb",
+                "reference": "154afe0378cd04b3bb6de6ab01b3c00ddfdd43fb",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.16",
+                "boundwize/structarmed": "^0.6.17",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -1109,7 +1109,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T06:37:46+00:00"
+            "time": "2026-05-21T12:10:41+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.16` to `0.6.17`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`