### PR TITLE
Update `boundwize/structarmed` to version `0.11.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.11.0",
+        "boundwize/structarmed": "^0.11.3",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07ce962a2b6931acbcd0f353251d2203",
+    "content-hash": "24024468719ecaa186ee80f7e82bc805",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -859,16 +859,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.11.0",
+            "version": "0.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "a12b7107c9b3b85da43f3416c477ca3e64e9d008"
+                "reference": "42a2520eda670609d701f9e6704b7d31d8d8b697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/a12b7107c9b3b85da43f3416c477ca3e64e9d008",
-                "reference": "a12b7107c9b3b85da43f3416c477ca3e64e9d008",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/42a2520eda670609d701f9e6704b7d31d8d8b697",
+                "reference": "42a2520eda670609d701f9e6704b7d31d8d8b697",
                 "shasum": ""
             },
             "require": {
@@ -921,7 +921,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.11.0"
+                "source": "https://github.com/boundwize/structarmed/tree/0.11.3"
             },
             "funding": [
                 {
@@ -929,7 +929,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-03T09:39:13+00:00"
+            "time": "2026-06-04T16:05:09+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.11.0` to `0.11.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`